### PR TITLE
Magento 2.3 Composer Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,12 +8,12 @@
         "fontis/auspost-api-php": "^1.0.5",
         "fontis/bpay-ref-generator": "^1.0.0|^2.0.0",
         "fontis/customergroupaccess-mage2": "^1.0.1",
-        "magento/framework": "100.*|101.*",
-        "magento/module-checkout": "100.*",
-        "magento/module-directory": "100.*",
-        "magento/module-payment": "100.*",
-        "magento/module-store": "100.*",
-        "magento/module-shipping": "100.*"
+        "magento/framework": "100.*|101.*|102.*",
+        "magento/module-checkout": "100.*|101.*|102.*",
+        "magento/module-directory": "100.*|101.*|102.*",
+        "magento/module-payment": "100.*|101.*|102.*",
+        "magento/module-store": "100.*|101.*|102.*",
+        "magento/module-shipping": "100.*|101.*|102.*"
     },
     "autoload": {
         "files": [

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -17,7 +17,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Fontis_Australia" setup_version="1.0.3">
+    <module name="Fontis_Australia" setup_version="1.0.4">
         <sequence>
             <module name="Magento_Checkout" />
             <module name="Magento_Directory" />


### PR DESCRIPTION
Updated composer.json requirements to include versions that are 2.3 compatible.
The specific Magento 2.3 feature adds aren't considered here, this is just getting an installable module using composer