### PR TITLE
Provide service name in getAllowedMethods function

### DIFF
--- a/Model/Shipping/Carrier/AustraliaPost.php
+++ b/Model/Shipping/Carrier/AustraliaPost.php
@@ -517,7 +517,7 @@ class AustraliaPost extends AbstractCarrier implements CarrierInterface
         $formatMethods = array();
 
         foreach ($methods as $method) {
-            $formatMethods[$method] = $this->getCode('services', $method);
+            $formatMethods[$method] = $this->getCode('services', $method) ?? "Unknown (" . $method . ")";
         }
 
         return $formatMethods;

--- a/Model/Shipping/Carrier/AustraliaPost.php
+++ b/Model/Shipping/Carrier/AustraliaPost.php
@@ -517,7 +517,7 @@ class AustraliaPost extends AbstractCarrier implements CarrierInterface
         $formatMethods = array();
 
         foreach ($methods as $method) {
-            $formatMethods[$method] = $this->getConfigData('title');
+            $formatMethods[$method] = $this->getCode('services', $method);
         }
 
         return $formatMethods;


### PR DESCRIPTION
Carrier name is currently provided as the value for every service in the getAllowedMethods function. This patch corrects this so that the service name is returned instead.